### PR TITLE
fix: update `inca.database.doctype_fields()`

### DIFF
--- a/inca/core/search_utils.py
+++ b/inca/core/search_utils.py
@@ -205,7 +205,7 @@ def doctype_fields(doctype):
     )["hits"]["total"]
     mappings = (
         _client.indices.get_mapping(_elastic_index)
-        .get(_elastic_index, {})
+        .popitem()[1]
         .get("mappings", {})
         .get("doc", {})
         .get("properties", {})


### PR DESCRIPTION
- problem:  `inca.database.doctype_fields()` returns an empty dict after changing the `document_index` in settings.cfg to refer to `inca_alias`. This is because the original code in this function expects the value of `document_index` to be the same as the name of the key returned by `_client.indices.get_mapping()`.

- fix: use `popitem()` to get the last item in the `_client.indices.get_mapping()` dict. This works on the assumption that `inca_alias` is associated with only one index at a time.`popitem()` returns a key-value pair so just return the value which contains the mapping dict.