### PR TITLE
feat: add standardize URL processor

### DIFF
--- a/inca/processing/usrightmedia_url_processing.py
+++ b/inca/processing/usrightmedia_url_processing.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+import logging
+import urlexpander
+
+from ..core.processor_class import Processer
+
+logger = logging.getLogger("INCA")
+
+
+class standardize_url(Processer):
+    """standardize a URL"""
+
+    def process(self, document_field, **kwargs):
+        """standardize a URL
+
+        Args:
+            document_field (str): the URL from the server
+
+        Returns:
+            standardized_url (str): the
+
+        """
+
+        standardized_url = urlexpander.url_utils.standardize_url(
+            url=document_field,
+            remove_scheme=True,
+            replace_netloc_with_domain=False,
+            remove_path=False,
+            remove_query=False,
+            remove_fragment=True,
+            to_lowercase=True,
+        )
+
+        return standardized_url


### PR DESCRIPTION
The scraped documents already have a `standardized_url` field which comes from an older version of urlExpander. Due to an update to the `standardize_url()`  logic, this processor will be used to re-run `standardize_url()` on the `resolved_url` key. The new version should be output to a new `standardized_url_2` field.