### PR TITLE
feat: add boolean processors

### DIFF
--- a/inca/processing/usrightmedia_should_include_processing.py
+++ b/inca/processing/usrightmedia_should_include_processing.py
@@ -6,6 +6,34 @@ from ..core.processor_class import Processer
 logger = logging.getLogger("INCA")
 
 
+class is_true_ind(Processer):
+    def process(self, document_field, **kwargs):
+        """Set the new_key value to True.
+
+        Args:
+            document_field (str): not used
+
+        Returns:
+            True
+
+        """
+        return True
+
+
+class is_false_ind(Processer):
+    def process(self, document_field, **kwargs):
+        """Set the new_key value to False.
+
+        Args:
+            document_field (str): not used
+
+        Returns:
+            False
+
+        """
+        return False
+
+
 class is_empty_text(Processer):
     def process(self, document_field, **kwargs):
         """Check if the text field is empty.


### PR DESCRIPTION
This PR adds basic processors for labeling boolean fields. These processors label all documents which are passed to it with either `True` or `False`, so they should be used when you want to add a new boolean key using custom logic that isn't available in INCA and/or doesn't match INCA's design for processors.

In INCA, the  processor class typically takes one field as input, processes it, and outputs the result to a new field. A processor can take `extra_fields` as well, as long as they already exist on the document. These processors make INCA flexible for creating new boolean fields.